### PR TITLE
Expose method to find intersecting bounding boxes

### DIFF
--- a/src/AnnotationStore.js
+++ b/src/AnnotationStore.js
@@ -156,6 +156,10 @@ export default class AnnotationStore {
     });
   }
 
+  getBounds = annotation => {
+    return this.getBounds(annotation, this.env.image);
+  }
+
   remove = annotation => {
     // Unfortunately, .remove currently requires bounds,
     // therefore we need to re-compute. See:

--- a/src/OSDAnnotationLayer.js
+++ b/src/OSDAnnotationLayer.js
@@ -706,6 +706,11 @@ export class AnnotationLayer extends EventEmitter {
   stopDrawing = () =>
     this.tools?.current?.stop();
 
+  getAnnotationsIntersecting = (annotation) => {
+    const bounds = this.store.getBounds(annotation);
+    return this.store.getAnnotationsIntersecting(bounds);
+  }
+
 }
 
 export default class OSDAnnotationLayer extends AnnotationLayer {

--- a/src/OpenSeadragonAnnotator.jsx
+++ b/src/OpenSeadragonAnnotator.jsx
@@ -294,6 +294,10 @@ export default class OpenSeadragonAnnotator extends Component {
   getAnnotations = () =>
     this.annotationLayer.getAnnotations().map(a => a.clone());
 
+  getAnnotationsIntersecting = (annotation) => {
+    return this.annotationLayer.getAnnotationsIntersecting(annotation);
+  }
+
   getImageSnippetById = annotationId =>
     this.annotationLayer.getImageSnippetById(annotationId);
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -171,6 +171,10 @@ class OSDAnnotorious {
     return annotations.map(a => a.underlying);
   }
 
+  getAnnotationsIntersecting = (annotationOrId) => {
+    return this._app.current.getAnnotationsIntersecting(this._wrap(annotationOrId));
+  }
+
   getImageSnippetById = annotationId =>
     this._app.current.getImageSnippetById(annotationId);
 


### PR DESCRIPTION
Exposes a method which returns the annotations whose
bounding boxes intersect with the bounding box of
the specified annotation.

It is meant for applications where an approximate
intersection is needed in respect to other annotations.