### PR TITLE
Fixes the invalid state

### DIFF
--- a/src/OSDAnnotationLayer.js
+++ b/src/OSDAnnotationLayer.js
@@ -140,15 +140,12 @@ export class AnnotationLayer extends EventEmitter {
   /** Initializes the OSD MouseTracker used for drawing **/
   _initDrawingTools = gigapixelMode => {
     let started = false;
-    
-    let firstDragDone = false;
 
     let dragging = false;
 
     this.tools = new DrawingTools(this.g, this.config, this.env);
 
     this.tools.on('complete', shape => {
-      firstDragDone = false;
       this.onDrawingComplete(shape);
     });
 
@@ -179,7 +176,7 @@ export class AnnotationLayer extends EventEmitter {
         if (this.tools.current.isDrawing) {
           const { x , y } = this.tools.current.getSVGPoint(evt.originalEvent);
  
-          if (!evt.buttons || !firstDragDone) {
+          if (!evt.buttons) {
             evt.originalEvent.stopPropagation();
 
             this.tools.current.onMouseMove(x, y, evt.originalEvent);
@@ -199,8 +196,6 @@ export class AnnotationLayer extends EventEmitter {
 
       releaseHandler: evt => {
         if (this.tools.current.isDrawing) {
-          firstDragDone = true;
-
           const { x , y } = this.tools.current.getSVGPoint(evt.originalEvent);
           this.tools.current.onMouseUp(x, y, evt.originalEvent);
 


### PR DESCRIPTION
The issue described here: https://matrix.to/#/!mRzqTfJoZKLxSbFGWS:gitter.im/$6raYmtiFt7Bm4oKUaWU93fbzdTIUvW5unw_Y6FZVpt4?via=gitter.im&via=matrix.org

It seems like buttons are alway true (1), it doesn’t seem to be called without button press. 
**Please correct** me if that's a wrong assumption since everything else builds around it. I tested only a small subset of cases (two tools: rect and poly).

Which means that means it can be simplified to
`if (!firstDragDone)`
Which is causing a bug according to this hypothesis.
When firstDragDone is set to “true” and not cleared (when existing annotation is clicked, not new created), we’re stuck in a bad state: we always go to `else` in the main `if` in `moveHandler` due to firstDragDone being stuck in true.

If all above is correct, the next step would be to remove the `if (!evt.buttons)` altogether.