### PR TITLE
Allow propagation on selectedShape scroll events

### DIFF
--- a/src/OSDAnnotationLayer.js
+++ b/src/OSDAnnotationLayer.js
@@ -707,7 +707,7 @@ export class AnnotationLayer extends EventEmitter {
           element: this.svg,
 
           preProcessEventHandler: info => {
-            info.stopPropagation = true;
+            info.stopPropagation = info.eventType !== "wheel";
             info.preventDefault = false;
             info.preventGesture = true;
           }


### PR DESCRIPTION
Normally when a user scrolls in OpenSeadragon, it just zooms the image in and out.

However, in Annotorious-OSD, when a shape is selected and the user scrolls with the mouse wheel, it both zooms the OSD canvas, and also scrolls the rest of the surrounding page. This behavior is visible on the old Annotorious OSD test site:
https://annotorious.github.io/getting-started/osd-plugin/ This is because because all events have `stopPropagation = true` on selected shapes.

Where we're using this in the Princeton Geniza Project, this can be problematic, as users may have an annotation shape selected, and be working on a transcription on another part of the screen at the same time. They want to be able to zoom the image with the scroll wheel without also scrolling the transcription.

I could make this configurable through an option, if the `wheel` event should sometimes not propagate.